### PR TITLE
fix void * arithmetic

### DIFF
--- a/libomptarget/plugins/smartnic/src/rtl.cpp
+++ b/libomptarget/plugins/smartnic/src/rtl.cpp
@@ -124,7 +124,9 @@ class SocketHandle {
     ssize_t recv_bytes = 0;
 
     do {
-      recv_bytes += recv(this->sockfd, data + recv_bytes, size, 0);
+      recv_bytes += recv(this->sockfd,
+                         static_cast<char*>(data) + recv_bytes,
+                         size, 0);
 
       if (recv_bytes < 0) {
         DP("[smartnic] recv data error!\n");


### PR DESCRIPTION
Arithmetic on void* is not covered by the standard. Use char* for this.